### PR TITLE
Fix :Lf for when shell is PowerShell.

### DIFF
--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -62,7 +62,7 @@ function! OpenLfIn(path, edit_cmd)
       startinsert
     else
       set guioptions+=! " Make it work with MacVim
-      let currentPath = expand(a:path)
+      let currentPath = expand(a:path) != "" ? expand(a:path) : getcwd()
       silent exec '!' . s:lf_command . ' -selection-path=' . s:choice_file_path . ' "' . currentPath . '"'
       if filereadable(s:choice_file_path)
         for f in readfile(s:choice_file_path)


### PR DESCRIPTION
If :Lf is run while there are no files being actively edited, then the
a:path expands to nothing, and PowerShell is unable to escape an empty
set of quotes, `""`, as commandline arguments.

To reproduce the symptoms, try "powershell.exe -command "echo """.

My first PR ever, please be gentle ! 

Thanks.