### PR TITLE
Use floating/popup windows using vim-floaterm & Add :Lfcd and :Lflcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The default shortcut for opening lf is `<leader>f` (\f by default).
 To disable the default key mapping, add this line in your .vimrc or init.vim: `let g:lf_map_keys = 0`.
 Then you can add a new mapping with this line: `map <leader>f :Lf<CR>`.
 
+To set the floating window width and height, set `g:lf_width` and `g:lf_height` accordingly. If not found, it will default to `g:floaterm_width` and `g:floaterm_height`.
+
 The command for opening lf in the current file's directory is `:Lf`.
 When opening (default 'l' and '\<right\>') a file from the lf window,
 vim will open the selected file in the current window. To open the selected

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ lf.vim
 
 [lf](https://github.com/gokcehan/lf) integration in vim and neovim
 
+![lf.vim](https://user-images.githubusercontent.com/56180050/100401445-70299b00-3094-11eb-945a-7caa04de696d.png)
+
 Installation
 ------------
 
@@ -38,19 +40,19 @@ Vim will open the selected file in the current window.
 `:LfWorkingDirectoryNewTab` will open the selected file in a new tab instead.
 
 List of commands:
-```
-Lf // open current file by default
-LfCurrentFile // Default Lf behaviour
+```vim
+Lf " Open current file by default
+LfCurrentFile " Default Lf behaviour
 LfCurrentDirectory
 LfWorkingDirectory
 
-// open always in new tabs
+" Always open in new tabs
 LfNewTab
 LfCurrentFileNewTab
 LfCurrentDirectoryNewTab
 LfWorkingDirectoryNewTab
 
-// open tab, when existant or in new tab when not existant
+" Open tab if it exists or in new tab if it does not
 LfCurrentFileExistingOrNewTab
 LfCurrentDirectoryExistingOrNewTab
 LfWorkingDirectoryExistingOrNewTab
@@ -62,9 +64,9 @@ supported but deprecated.
 
 ### Opening lf instead of netrw when you open a directory
 If you want to see vim opening lf when you open a directory (ex: nvim ./dir or :edit ./dir), please add this in your .(n)vimrc.
-```
-let g:NERDTreeHijackNetrw = 0 // add this line if you use NERDTree
-let g:lf_replace_netrw = 1 // open lf when vim open a directory
+```vim
+let g:NERDTreeHijackNetrw = 0 " Add this line if you use NERDTree
+let g:lf_replace_netrw = 1 " Open lf when vim opens a directory
 ```
 
 In order for this to work you need to install the bclose.vim plugin (see above).
@@ -73,6 +75,6 @@ In order for this to work you need to install the bclose.vim plugin (see above).
 By default lf is opened with the command `lf` but you can set an other custom command by setting the `g:lf_command_override` variable in your .(n)vimrc.
 
 For instance if you want to display the hidden files by default you can write:
-```
+```vim
 let g:lf_command_override = 'lf -command "set hidden"'
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install it with your favorite plugin manager. Example with vim-plug:
 
         Plug 'ptzz/lf.vim'
 
+Then, you need to add vim-floaterm for the floating/popup window dependency:
+
+        Plug 'voldikss/vim-floaterm'
+
 If you use neovim, you have to add the dependency to the plugin bclose.vim:
 
         Plug 'rbgrouleff/bclose.vim'
@@ -72,9 +76,3 @@ For instance if you want to display the hidden files by default you can write:
 ```
 let g:lf_command_override = 'lf -command "set hidden"'
 ```
-
-## Common issues
-
-### Using fish shell (issue #42)
-Solution: if you use something else than bash or zsh you should probably need to add this line in your .vimrc:
-`set shell=bash`

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ Install it with your favorite plugin manager. Example with vim-plug:
 
         Plug 'ptzz/lf.vim'
 
-Then, you need to add vim-floaterm for the floating/popup window dependency:
+Then, add the vim-floaterm dependency:
 
         Plug 'voldikss/vim-floaterm'
 
 **Note:** lf.vim should be loaded before vim-floaterm to override vim-floaterm's lf wrapper.
-
-If you use neovim, you have to add the dependency to the plugin bclose.vim:
-
-        Plug 'rbgrouleff/bclose.vim'
 
 How to use it
 -------------
@@ -41,8 +37,14 @@ For opening lf in the current workspace, run `:LfWorkingDirectory`.
 Vim will open the selected file in the current window.
 `:LfWorkingDirectoryNewTab` will open the selected file in a new tab instead.
 
+For changing the current directory via lf, run `:Lfcd`or run `:Lflcd` for the current window.
+
 List of commands:
 ```vim
+" Change directory with lf via cd or lcd
+Lfcd
+Lflcd
+
 Lf " Open current file by default
 LfCurrentFile " Default Lf behaviour
 LfCurrentDirectory
@@ -70,8 +72,6 @@ If you want to see vim opening lf when you open a directory (ex: nvim ./dir or :
 let g:NERDTreeHijackNetrw = 0 " Add this line if you use NERDTree
 let g:lf_replace_netrw = 1 " Open lf when vim opens a directory
 ```
-
-In order for this to work you need to install the bclose.vim plugin (see above).
 
 ### Setting a custom lf command
 By default lf is opened with the command `lf` but you can set an other custom command by setting the `g:lf_command_override` variable in your .(n)vimrc.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Then, you need to add vim-floaterm for the floating/popup window dependency:
 
         Plug 'voldikss/vim-floaterm'
 
+**Note:** lf.vim should be loaded before vim-floaterm to override vim-floaterm's lf wrapper.
+
 If you use neovim, you have to add the dependency to the plugin bclose.vim:
 
         Plug 'rbgrouleff/bclose.vim'

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -1,10 +1,11 @@
 function! floaterm#wrapper#lf#(cmd) abort
   let lf_tmpfile = tempname()
+  let lastdir_tmpfile = tempname()
   let original_dir = getcwd()
   lcd %:p:h
 
   let cmdlist = split(a:cmd)
-  let cmd = 'lf -selection-path="' . lf_tmpfile . '"'
+  let cmd = 'lf -last-dir-path="' . lastdir_tmpfile . '" -selection-path="' . lf_tmpfile . '"'
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
@@ -12,5 +13,5 @@ function! floaterm#wrapper#lf#(cmd) abort
   endif
 
   exe "lcd " . original_dir
-  return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile])}, v:false]
+  return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile, lastdir_tmpfile])}, v:false]
 endfunction

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -1,0 +1,16 @@
+function! floaterm#wrapper#lf#(cmd) abort
+  let lf_tmpfile = tempname()
+  let original_dir = getcwd()
+  lcd %:p:h
+
+  let cmdlist = split(a:cmd)
+  let cmd = 'lf -selection-path="' . lf_tmpfile . '"'
+  if len(cmdlist) > 1
+    let cmd .= ' ' . join(cmdlist[1:], ' ')
+  else
+    let cmd .= ' "' . getcwd() . '"'
+  endif
+
+  exe "lcd " . original_dir
+  return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile])}, v:false]
+endfunction

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -13,6 +13,5 @@ function! floaterm#wrapper#lf#(cmd) abort
   endif
 
   exe "lcd " . original_dir
-  let cmd = [&shell, &shellcmdflag, cmd]
   return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile, lastdir_tmpfile])}, v:false]
 endfunction

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -13,5 +13,6 @@ function! floaterm#wrapper#lf#(cmd) abort
   endif
 
   exe "lcd " . original_dir
+  let cmd = [&shell, &shellcmdflag, cmd]
   return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile, lastdir_tmpfile])}, v:false]
 endfunction

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -33,7 +33,7 @@ function! OpenLfIn(path, edit_cmd)
   let currentPath = expand(a:path)
   let s:edit_cmd = a:edit_cmd
   if exists(":FloatermNew")
-    exec 'FloatermNew ' . s:lf_command . ' ' . currentPath
+    exec 'FloatermNew ' . '--height=' . string(get(g:, 'lf_height', g:floaterm_height)) . ' --width=' . string(get(g:, 'lf_width', g:floaterm_width)) . ' ' . s:lf_command . ' ' . currentPath
   else
     echoerr "Failed to open a floating terminal. Make sure `voldikss/vim-floaterm` is installed."
   endif

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -51,18 +51,24 @@ function! LfCallback(lf_tmpfile, lastdir_tmpfile, ...) abort
     let filenames = readfile(a:lf_tmpfile)
     if !empty(filenames)
       if has('nvim')
-        call floaterm#window#hide_floaterm(bufnr('%'))
+        call floaterm#window#hide(bufnr('%'))
       endif
+      let locations = []
       if edit_cmd != 'default'
         for filename in filenames
-          exec edit_cmd . ' ' . fnameescape(filename)
+          let dict = {'filename': fnamemodify(filename, ':p')}
+
+          call add(locations, dict)
         endfor
         unlet s:edit_cmd
       else
         for filename in filenames
-          exec g:floaterm_open_command . ' ' . fnameescape(filename)
+          let dict = {'filename': fnamemodify(filename, ':p')}
+
+          call add(locations, dict)
         endfor
       endif
+      call floaterm#util#open(g:floaterm_open_command, locations)
     endif
   endif
 endfunction


### PR DESCRIPTION
Here's what it looks like:
![image](https://user-images.githubusercontent.com/56180050/100401445-70299b00-3094-11eb-945a-7caa04de696d.png)

The BClose dependency is not needed anymore.
Fixes https://github.com/francoiscabrol/ranger.vim/issues/42 as well.
Added :Lfcd and :Lflcd similar to that of [rafaqz/ranger.vim](https://github.com/rafaqz/ranger.vim)