### PR TITLE
Disable `showmode` and `relativenumber` options

### DIFF
--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -34,9 +34,12 @@ endif
 function! OpenLfIn(path, edit_cmd)
   let oldguioptions = &guioptions
   let s:oldlaststatus = &laststatus
+  let s:oldshowmode = &showmode
+  let s:oldrelativenumber = &relativenumber
   try
     if has('nvim')
       set laststatus=0
+      set noshowmode norelativenumber
       let currentPath = expand(a:path)
       let lfCallback = { 'name': 'lf', 'edit_cmd': a:edit_cmd }
       function! lfCallback.on_exit(job_id, code, event)
@@ -56,6 +59,8 @@ function! OpenLfIn(path, edit_cmd)
           endif
         endtry
         let &laststatus=s:oldlaststatus
+        let &showmode=s:oldshowmode
+        let &relativenumber=s:oldrelativenumber
       endfunction
       enew
       call termopen(s:lf_command . ' -selection-path=' . s:choice_file_path . ' "' . currentPath . '"', lfCallback)


### PR DESCRIPTION
Partially solves https://github.com/ptzz/lf.vim/issues/13
Looks cleaner now.
The original values are restored when Lf is closed.
I implemented this for nvim since I don't have a way to test for MacVim.
I tried disabling the line numbers completely but a strange artifact appeared (the buffer scrolls in character left when the preview is completely filled).