### PR TITLE
WIP: Remove Bclose dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Install it with your favorite plugin manager. Example with vim-plug:
 
         Plug 'ptzz/lf.vim'
 
-If you use neovim, you have to add the dependency to the plugin bclose.vim:
-
-        Plug 'rbgrouleff/bclose.vim'
+If you use neovim, make sure you have the [Neovim HEAD/nightly](https://github.com/neovim/neovim/releases/tag/nightly).
 
 How to use it
 -------------

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -44,11 +44,7 @@ function! OpenLfIn(path, edit_cmd)
       let lfCallback = { 'name': 'lf', 'edit_cmd': a:edit_cmd }
       function! lfCallback.on_exit(job_id, code, event)
         if a:code == 0
-          if exists(":Bclose")
-            silent! Bclose!
-          else
-            echoerr "Failed to close buffer, make sure the `rbgrouleff/bclose.vim` plugin is installed"
-          endif
+          silent! bdelete!
         endif
         try
           if filereadable(s:choice_file_path)
@@ -115,7 +111,7 @@ function! OpenLfOnVimLoadDir(argv_path)
   let path = expand(a:argv_path)
 
   " Delete empty buffer created by vim
-  Bclose!
+  bdelete!
 
   " Open Lf
   call OpenLfIn(path, s:default_edit_cmd)


### PR DESCRIPTION
Fixes https://github.com/ptzz/lf.vim/issues/14

`bdelete!` has been fixed in neovim nightly

- updated README
- replaced `Bclose!` calls with `bdelete!`