### PR TITLE
Fix breaking changes to g:floaterm_open_command in vim-floaterm wrapper:

### DIFF
--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -60,15 +60,18 @@ function! LfCallback(lf_tmpfile, lastdir_tmpfile, ...) abort
 
           call add(locations, dict)
         endfor
-        call floaterm#util#open(s:edit_cmd, locations)
+        let s:old_opener = g:floaterm_opener
+        let g:floaterm_opener = s:edit_cmd
+        call floaterm#util#open(locations)
         unlet s:edit_cmd
+        let g:floaterm_opener = s:old_opener
       else
         for filename in filenames
           let dict = {'filename': fnamemodify(filename, ':p')}
 
           call add(locations, dict)
         endfor
-        call floaterm#util#open(g:floaterm_open_command, locations)
+        call floaterm#util#open(locations)
       endif
     endif
   endif
@@ -76,7 +79,7 @@ endfunction
 
 " For backwards-compatibility (deprecated)
 if exists('g:lf_open_new_tab') && g:lf_open_new_tab
-  let s:default_edit_cmd='tabedit'
+  let s:default_edit_cmd='tabe'
 else
   let s:default_edit_cmd='edit'
 endif
@@ -89,12 +92,12 @@ command! LfWorkingDirectory call OpenLfIn(".", s:default_edit_cmd)
 command! Lf LfCurrentFile
 
 " To open the selected file in a new tab
-command! LfCurrentFileNewTab call OpenLfIn("%", 'tabedit')
-command! LfCurrentFileExistingOrNewTab call OpenLfIn("%", 'tab drop')
-command! LfCurrentDirectoryNewTab call OpenLfIn("%:p:h", 'tabedit')
-command! LfCurrentDirectoryExistingOrNewTab call OpenLfIn("%:p:h", 'tab drop')
-command! LfWorkingDirectoryNewTab call OpenLfIn(".", 'tabedit')
-command! LfWorkingDirectoryExistingOrNewTab call OpenLfIn(".", 'tab drop')
+command! LfCurrentFileNewTab call OpenLfIn("%", 'tabe')
+command! LfCurrentFileExistingOrNewTab call OpenLfIn("%", 'drop')
+command! LfCurrentDirectoryNewTab call OpenLfIn("%:p:h", 'tabe')
+command! LfCurrentDirectoryExistingOrNewTab call OpenLfIn("%:p:h", 'drop')
+command! LfWorkingDirectoryNewTab call OpenLfIn(".", 'tabe')
+command! LfWorkingDirectoryExistingOrNewTab call OpenLfIn(".", 'drop')
 command! LfNewTab LfCurrentDirectoryNewTab
 
 " For retro-compatibility


### PR DESCRIPTION
Fixes #23.

I hope this is helpful, but perhaps there is a more elegant way to avoid overwriting the user's `g:floaterm_opener`, which could be set independently of this wrapper.

- Remove g:floaterm_open_command in favour of g:floaterm_opener_command

- Set g:floaterm_opener equal to s:edit_cmd without overwriting the
  default or user-set value (we save it and reset it afterwards)

- Rename "tabedit" --> "tabe" and "tab drop" --> "drop" (g:floaterm_opener
values)