### PR TITLE
Fix opening directory not working in Windows

### DIFF
--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -13,5 +13,6 @@ function! floaterm#wrapper#lf#(cmd) abort
   endif
 
   exe "lcd " . original_dir
+  let cmd = [&shell, &shellcmdflag, cmd]
   return [cmd, {'on_exit': funcref('LfCallback', [lf_tmpfile, lastdir_tmpfile])}, v:false]
 endfunction

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -30,10 +30,10 @@ else
 endif
 
 function! OpenLfIn(path, edit_cmd)
-  let currentPath = shellescape(expand(a:path))
+  let currentPath = shellescape(fnamemodify(expand(a:path), ":p:h"))
   let s:edit_cmd = a:edit_cmd
   if exists(":FloatermNew")
-    exec 'FloatermNew ' . '--height=' . string(get(g:, 'lf_height', g:floaterm_height)) . ' --width=' . string(get(g:, 'lf_width', g:floaterm_width)) . ' ' . s:lf_command . ' ' . currentPath
+    exec 'FloatermNew' . ' --height=' . string(get(g:, 'lf_height', g:floaterm_height)) . ' --width=' . string(get(g:, 'lf_width', g:floaterm_width)) . ' ' . s:lf_command . ' ' . currentPath
   else
     echoerr "Failed to open a floating terminal. Make sure `voldikss/vim-floaterm` is installed."
   endif

--- a/plugin/lf.vim
+++ b/plugin/lf.vim
@@ -30,7 +30,7 @@ else
 endif
 
 function! OpenLfIn(path, edit_cmd)
-  let currentPath = shellescape(fnamemodify(expand(a:path), ":p:h"))
+  let currentPath = shellescape(isdirectory(a:path) ? fnamemodify(expand(a:path), ":p:h") : expand(a:path))
   let s:edit_cmd = a:edit_cmd
   if exists(":FloatermNew")
     exec 'FloatermNew' . ' --height=' . string(get(g:, 'lf_height', g:floaterm_height)) . ' --width=' . string(get(g:, 'lf_width', g:floaterm_width)) . ' ' . s:lf_command . ' ' . currentPath


### PR DESCRIPTION
With the fix for #19 (https://github.com/ptzz/lf.vim/commit/9d333aaea4967e3e738c77a8f6ffe466beb2bcee), opening a directory causes an error and instead always opens on home in windows if there is a slash in front of the directory. This change fixes it.